### PR TITLE
In BLF notify generated by RLS module, the multipart body contains a …

### DIFF
--- a/modules/rls/notify.c
+++ b/modules/rls/notify.c
@@ -1026,14 +1026,14 @@ char* generate_cid(char* uri, int uri_len)
 	char* cid;
 	int len;
 
-	cid = (char*) pkg_malloc(uri_len + 30);
+	cid = (char*) pkg_malloc(max_contentid_len+2);
 	if(cid == NULL)
 	{
 		LM_ERR("no more memory\n");
 		return NULL;
 	}
 
-	len= sprintf(cid, "%d.%.*s.%d", (int)time(NULL), uri_len, uri, rand());
+	len= snprintf(cid, max_contentid_len, "%d.%.*s.%d", (int)time(NULL), uri_len, uri, rand());
 	cid[len]= '\0';
 
 	return cid;

--- a/modules/rls/rls.c
+++ b/modules/rls/rls.c
@@ -67,6 +67,8 @@ db_func_t rls_dbf;
 str server_address= {0, 0};
 str presence_server= {0, 0};
 int waitn_time = 50;
+/* some cisco device has limitation on the max Content-ID length in the multipart body */
+int max_contentid_len = 128;
 str rlsubs_table= str_init("rls_watchers");
 str rlpres_table= str_init("rls_presentity");
 
@@ -180,6 +182,7 @@ static param_export_t params[]={
 	{ "rlsubs_table",           STR_PARAM, &rlsubs_table.s             },
 	{ "rlpres_table",           STR_PARAM, &rlpres_table.s             },
 	{ "waitn_time",             INT_PARAM, &waitn_time                 },
+	{ "max_contentid_len",      INT_PARAM, &max_contentid_len          },
 	{ "clean_period",           INT_PARAM, &clean_period               },
 	{ "max_expires",            INT_PARAM, &rls_max_expires            },
 	{ "hash_size",              INT_PARAM, &hash_size                  },
@@ -392,6 +395,9 @@ static int mod_init(void)
 
 	if(waitn_time<= 0)
 		waitn_time= 50;
+
+	if(max_contentid_len<= 0)
+		max_contentid_len= 128;
 
 	/* bind libxml wrapper functions */
 

--- a/modules/rls/rls.h
+++ b/modules/rls/rls.h
@@ -84,6 +84,7 @@ extern unsigned int xcap_port;
 extern str server_address;
 extern str presence_server;
 extern int waitn_time;
+extern int max_contentid_len;
 extern str rlsubs_table;
 extern str rlpres_table;
 extern int hash_size;


### PR DESCRIPTION
…few sections. Each section has a few header. Among them, Content-ID is a header with randomly generated IDs. CISCO device has limitations on the length of the Content-ID field. We created a new param for RLS module to adjust it in case it is necessary. For CISCO device, set it as modparam("rls", "max_contentid_len", 54) fix the device issue.