### PR TITLE
Sometimes NOTIFY body contains multiple presence status for a specifi…

### DIFF
--- a/modules/presence/notify.c
+++ b/modules/presence/notify.c
@@ -1142,7 +1142,7 @@ str* get_p_notify_body(str pres_uri, pres_ev_t* event, str* etag, str* publ_body
 			LM_DBG("searched etag = %.*s len= %d\n",
 					etag->len, etag->s, etag->len);
 			LM_DBG("etag not NULL\n");
-			for(i= 0; i< n; i++)
+			for(i= (aggregate_presence == 0 ? n-1 : 0); i< n; i++)
 			{
 				row = &result->rows[i];
 				row_vals = ROW_VALUES(row);
@@ -1196,7 +1196,7 @@ str* get_p_notify_body(str pres_uri, pres_ev_t* event, str* etag, str* publ_body
 		}
 		else
 		{
-			for(i=0; i< n; i++)
+			for(i= (aggregate_presence == 0 ? n-1 : 0); i< n; i++)
 			{
 				row = &result->rows[i];
 				row_vals = ROW_VALUES(row);

--- a/modules/presence/presence.c
+++ b/modules/presence/presence.c
@@ -116,6 +116,8 @@ int mix_dialog_presence= 0;
 int notify_offline_body= 0;
 /* if subscription should be automatically ended on SIP timeout 408 */
 int end_sub_on_timeout= 1;
+/* if the presence event should be aggregated in NOTIFY */
+int aggregate_presence = 1;
 /* holder for the pointer to presence event */
 pres_ev_t** pres_event_p= NULL;
 pres_ev_t** dialog_event_p= NULL;
@@ -163,6 +165,7 @@ static param_export_t params[]={
 	{ "bla_fix_remote_target",  INT_PARAM, &fix_remote_target},
 	{ "notify_offline_body",    INT_PARAM, &notify_offline_body},
 	{ "end_sub_on_timeout",     INT_PARAM, &end_sub_on_timeout},
+	{ "aggregate_presence",     INT_PARAM, &aggregate_presence},
 	{0,0,0}
 };
 

--- a/modules/presence/presence.h
+++ b/modules/presence/presence.h
@@ -64,6 +64,7 @@ extern shtable_t subs_htable;
 extern int mix_dialog_presence;
 extern int notify_offline_body;
 extern int end_sub_on_timeout;
+extern int aggregate_presence;
 
 extern int phtable_size;
 extern phtable_t* pres_htable;


### PR DESCRIPTION
…c extension. This confuses the device so it won't show status properly. We have added a new modparam 'aggregate_presence'. When it sets to 0, the NOTIFY body will only contain the most recent presence status for a specific extension. The default value is 1 which is the original behavior.