### PR TITLE
Feature/no rtpp healthcheck percall

### DIFF
--- a/modules/rtpproxy/rtpproxy.c
+++ b/modules/rtpproxy/rtpproxy.c
@@ -2366,7 +2366,7 @@ select_rtpp_node(struct sip_msg * msg,
 	pv_value_t val;
 
 	my_version = *list_version;
-	/* check last list version 
+	/* skip healthcheck on each call (check last list version)
 	if (my_version != *list_version && update_rtpp_proxies() < 0) {
 		LM_ERR("cannot update rtpp proxies list\n");
 		return 0;
@@ -2473,11 +2473,12 @@ search_rtpp_node(struct rtpp_set *set, char * url)
 	}
 
 	LM_DBG("Searching for node with url=%s\n", url);
-	/* check last list version */
+	my_version = *list_version;
+	/* skip healthcheck on each call (check last list version)
 	if (my_version != *list_version && update_rtpp_proxies() < 0) {
 		LM_ERR("cannot update rtpp proxies list\n");
 		return NULL;
-	}
+	} */
 
 	if (!set) {
 		LM_ERR("no set specified\n");

--- a/modules/rtpproxy/rtpproxy.c
+++ b/modules/rtpproxy/rtpproxy.c
@@ -2365,11 +2365,12 @@ select_rtpp_node(struct sip_msg * msg,
 	int was_forced, sumcut, found, constant_weight_sum;
 	pv_value_t val;
 
-	/* check last list version */
+	my_version = *list_version;
+	/* check last list version 
 	if (my_version != *list_version && update_rtpp_proxies() < 0) {
 		LM_ERR("cannot update rtpp proxies list\n");
 		return 0;
-	}
+	} */
 
 	if (!set) {
 		LM_ERR("no set specified\n");


### PR DESCRIPTION
This prevents RTPproxy from rescanning its sockets on every offer or answer.

It'll still do a version check against each active RTP and being attempting that rtpp node again after the recheck timeout.

Each rtpproxy socket is also retested with each reload we do once a minute, ticks and timeout are reset at that time when it is retested.