### PR TITLE
Hotfix/CPATL-1254

### DIFF
--- a/modules/proto_bin/proto_bin.c
+++ b/modules/proto_bin/proto_bin.c
@@ -290,7 +290,7 @@ poll_loop:
 		}
 	}
 
-	if (pf.events&POLLOUT)
+	if (pf.revents&POLLOUT)
 		goto again;
 
 	/* some other events triggered by poll - treat as errors */

--- a/modules/proto_hep/proto_hep.c
+++ b/modules/proto_hep/proto_hep.c
@@ -434,7 +434,7 @@ poll_loop:
 		}
 	}
 
-	if (pf.events&POLLOUT)
+	if (pf.revents&POLLOUT)
 		goto again;
 
 	/* some other events triggered by poll - treat as errors */

--- a/net/proto_tcp/proto_tcp.c
+++ b/net/proto_tcp/proto_tcp.c
@@ -706,7 +706,7 @@ poll_loop:
 		}
 	}
 
-	if (pf.events&POLLOUT)
+	if (pf.revents&POLLOUT)
 		goto again;
 
 	/* some other events triggered by poll - treat as errors */


### PR DESCRIPTION
TCP pollout event check fix. Package opensips_2.3.3-23_amd64.deb built from this branch. After Emily confirms the changes work as expected under load, we'll merge branch with base.