### PR TITLE
Bugfix/tcp no new conn rplflag

### DIFF
--- a/cfg.lex
+++ b/cfg.lex
@@ -337,6 +337,7 @@ TCP_CON_LIFETIME    "tcp_connection_lifetime"
 TCP_LISTEN_BACKLOG   "tcp_listen_backlog"
 TCP_MAX_CONNECTIONS "tcp_max_connections"
 TCP_NO_NEW_CONN_BFLAG "tcp_no_new_conn_bflag"
+TCP_NO_NEW_CONN_RPLFLAG "tcp_no_new_conn_rplflag"
 TCP_KEEPALIVE           "tcp_keepalive"
 TCP_KEEPCOUNT           "tcp_keepcount"
 TCP_KEEPIDLE            "tcp_keepidle"
@@ -608,6 +609,7 @@ IMPORTFILE      "import_file"
 <INITIAL>{SIP_WARNING}	{ count(); yylval.strval=yytext; return SIP_WARNING; }
 <INITIAL>{MHOMED}	{ count(); yylval.strval=yytext; return MHOMED; }
 <INITIAL>{TCP_NO_NEW_CONN_BFLAG}    { count(); yylval.strval=yytext; return TCP_NO_NEW_CONN_BFLAG; }
+<INITIAL>{TCP_NO_NEW_CONN_RPLFLAG}    { count(); yylval.strval=yytext; return TCP_NO_NEW_CONN_RPLFLAG; }
 <INITIAL>{TCP_CHILDREN}	{ count(); yylval.strval=yytext; return TCP_CHILDREN; }
 <INITIAL>{TCP_ACCEPT_ALIASES}	{ count(); yylval.strval=yytext;
 									return TCP_ACCEPT_ALIASES; }

--- a/cfg.y
+++ b/cfg.y
@@ -373,6 +373,7 @@ static struct multi_str *tmp_mod;
 %token TCP_LISTEN_BACKLOG
 %token TCP_MAX_CONNECTIONS
 %token TCP_NO_NEW_CONN_BFLAG
+%token TCP_NO_NEW_CONN_RPLFLAG
 %token TCP_KEEPALIVE
 %token TCP_KEEPCOUNT
 %token TCP_KEEPIDLE
@@ -901,6 +902,15 @@ assign_stm: DEBUG EQUAL snumber
 				flag_idx2mask( &tcp_no_new_conn_bflag );
 		}
 		| TCP_NO_NEW_CONN_BFLAG EQUAL error { yyerror("number value expected"); }
+		| TCP_NO_NEW_CONN_RPLFLAG EQUAL ID {
+				tcp_no_new_conn_rplflag =
+					get_flag_id_by_name(FLAG_TYPE_MSG, $3);
+				if (!flag_in_range( (flag_t)tcp_no_new_conn_rplflag ) )
+					yyerror("invalid TCP no_new_conn RePLy Flag");
+				flag_idx2mask( &tcp_no_new_conn_rplflag );
+		}
+		| TCP_NO_NEW_CONN_RPLFLAG EQUAL error { yyerror("number value expected"); }
+
 		| TCP_KEEPALIVE EQUAL NUMBER {
 				tcp_keepalive=$3;
 		}

--- a/forward.c
+++ b/forward.c
@@ -535,10 +535,16 @@ int forward_reply(struct sip_msg* msg)
 		goto error;
 	}
 
+	if (msg->flags & tcp_no_new_conn_rplflag)
+		tcp_no_new_conn = 1;
+
 	if (msg_send(send_sock, proto, to, id, new_buf, new_len, msg)<0) {
+	    tcp_no_new_conn = 0;
 		update_stat( drp_rpls, 1);
 		goto error0;
 	}
+	tcp_no_new_conn = 0;
+
 	update_stat( fwd_rpls, 1);
 	/*
 	 * If no port is specified in the second via, then this

--- a/globals.h
+++ b/globals.h
@@ -65,6 +65,7 @@ extern int tcp_keepinterval;
 extern int tcp_max_msg_time;
 extern int tcp_no_new_conn;
 extern int tcp_no_new_conn_bflag;
+extern int tcp_no_new_conn_rplflag;
 
 extern int no_daemon_mode;
 extern int debug_mode;

--- a/modules/tm/t_cancel.c
+++ b/modules/tm/t_cancel.c
@@ -108,7 +108,10 @@ void cancel_branch( struct cell *t, int branch )
 	}
 
 	LM_DBG("sending cancel...\n");
+	if (t->uac[branch].br_flags & tcp_no_new_conn_bflag)
+		tcp_no_new_conn = 1;
 	SEND_BUFFER( crb );
+	tcp_no_new_conn = 0;
 
 	/*sets and starts the FINAL RESPONSE timer */
 	start_retr( crb );

--- a/modules/tm/t_reply.c
+++ b/modules/tm/t_reply.c
@@ -316,7 +316,13 @@ static int send_ack(struct sip_msg* rpl, struct cell *trans, int branch)
 			trans, trans->uas.request, 0, 0);
 	}
 
+	if (trans->uac[branch].br_flags & tcp_no_new_conn_bflag)
+		tcp_no_new_conn = 1;
+
 	SEND_PR_BUFFER(&trans->uac[branch].request, ack_buf.s, ack_buf.len);
+
+	tcp_no_new_conn = 0;
+
 	shm_free(ack_buf.s);
 
 	return 0;
@@ -420,9 +426,15 @@ static int _reply_light( struct cell *trans, char* buf, unsigned int len,
 	if (!trans->uas.response.dst.send_sock) {
 		LM_CRIT("send_sock is NULL\n");
 	}
+
+	if(trans->uas.request && trans->uas.request->flags&tcp_no_new_conn_rplflag)
+		tcp_no_new_conn = 1;
+
 	SEND_PR_BUFFER( rb, buf, len );
 	LM_DBG("reply sent out. buf=%p: %.9s..., "
 		"shmem=%p: %.9s\n", buf, buf, rb->buffer.s, rb->buffer.s );
+
+	tcp_no_new_conn = 0;
 
 	if (has_tran_tmcbs(trans, TMCB_MSG_SENT_OUT) ) {
 		cb_s.s = buf;
@@ -1014,7 +1026,12 @@ int t_retransmit_reply( struct cell *t )
 	}
 	memcpy( b, t->uas.response.buffer.s, len );
 	UNLOCK_REPLIES( t );
+
+	if (t->uas.request && t->uas.request->flags & tcp_no_new_conn_rplflag)
+		tcp_no_new_conn = 1;
 	SEND_PR_BUFFER( & t->uas.response, b, len );
+	tcp_no_new_conn = 0;
+
 	LM_DBG("buf=%p: %.9s..., shmem=%p: %.9s\n",b, b, t->uas.response.buffer.s,
 			t->uas.response.buffer.s );
 	if (has_tran_tmcbs( t, TMCB_MSG_SENT_OUT) ) {
@@ -1265,7 +1282,12 @@ enum rps relay_reply( struct cell *t, struct sip_msg *p_msg, int branch,
 			run_trans_callbacks_locked(TMCB_RESPONSE_PRE_OUT,t,t->uas.request,
 				relayed_msg, relayed_code);
 		}
+
+		if (t->uas.request && t->uas.request->flags & tcp_no_new_conn_rplflag)
+			tcp_no_new_conn = 1;
 		SEND_PR_BUFFER( uas_rb, buf, res_len );
+		tcp_no_new_conn = 0;
+
 		LM_DBG("sent buf=%p: %.9s..., shmem=%p: %.9s\n",
 			buf, buf, uas_rb->buffer.s, uas_rb->buffer.s );
 

--- a/modules/tm/uac.c
+++ b/modules/tm/uac.c
@@ -470,11 +470,16 @@ abort_update:
 		REF_UNSAFE(new_cell);
 	}
 
+	if (new_cell->uac[0].br_flags & tcp_no_new_conn_bflag)
+		tcp_no_new_conn = 1;
+
 	if (SEND_BUFFER(request) == -1) {
 		LM_ERR("attempt to send to '%.*s' failed\n",
 			dialog->hooks.next_hop->len,
 			dialog->hooks.next_hop->s);
 	}
+
+	tcp_no_new_conn = 0;
 
 	if (method->len==ACK_LEN && memcmp(method->s, ACK, ACK_LEN)==0 ) {
 		t_release_transaction(new_cell);

--- a/net/net_tcp.c
+++ b/net/net_tcp.c
@@ -118,9 +118,12 @@ int tcp_keepcount = 0;
 int tcp_keepidle = 0;
 int tcp_keepinterval = 0;
 
-/*!< should a new TCP conn be open if needed? - branch flag to be set in
- * the SIP messages - configuration option */
+/*!< should we allow opening a new TCP conn when sending data
+ * over UAC branches? - branch flag to be set in the SIP messages */
 int tcp_no_new_conn_bflag = 0;
+/*!< should we allow opening a new TCP conn when sending data
+ * back to UAS (replies)? - msg flag to be set in the SIP messages */
+int tcp_no_new_conn_rplflag = 0;
 /*!< should a new TCP conn be open if needed? - variable used to used for
  * signalizing between SIP layer (branch flag) and TCP layer (tcp_send func)*/
 int tcp_no_new_conn = 0;


### PR DESCRIPTION
Backported the following commits:

1) commit 3ed5419 - Add the tcp_no_new_conn_rplflag to avoid opening TCP conns on the UAS side of the transaction (sending back the replies) 

2) commit - d3a0aaa -  Check the tcp_no_new_conn_bflag (to avoid opening TCP conns) when:
* sending a cancel to an invite (which was marked)
* sending a negative ACK to an invite (which was marked)
* sending a local UAC request (marked via local route)

