### PR TITLE
tm: check branches that should be cancelled under lock

### DIFF
--- a/modules/tm/t_cancel.c
+++ b/modules/tm/t_cancel.c
@@ -91,6 +91,7 @@ void cancel_branch( struct cell *t, int branch )
 	}
 #	endif
 
+
 	cancel=build_cancel(t, branch, &len);
 	if (!cancel) {
 		LM_ERR("attempt to build a CANCEL failed\n");

--- a/modules/tm/t_fwd.c
+++ b/modules/tm/t_fwd.c
@@ -586,8 +586,12 @@ void cancel_invite(struct sip_msg *cancel_msg,
 		reason.len = sizeof(CANCEL_REASON_SIP_487) - 1;
 	}
 
+	LOCK_REPLIES(t_invite);
+	/* we need to check which branches should be canceled under lock to avoid
+	 * concurrency with replies that are coming in the same time */
 	/* generate local cancels for all branches */
 	which_cancel(t_invite, &cancel_bitmap );
+	UNLOCK_REPLIES(t_invite);
 
 	set_cancel_extra_hdrs( reason.s, reason.len);
 	cancel_uacs(t_invite, cancel_bitmap );


### PR DESCRIPTION
This fix avoids race condition between a CANCEL message and replies that
are coming in the same time.

Thanks go to Tommy Brecher for reprting this and offering extensive logs
to debug the issue in ticket #1759.
Credits for the fix are shared with Bogdan Iancu for the brainstoring.

(cherry picked from commit 6e39385233543ee9583469c55d3d3d1738917fb7)
(cherry picked from commit 2e1d01fb3363138d5af3203793fa10dbe8e10a27)